### PR TITLE
added functionality for parsing float types with empty str as nan

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -3,6 +3,7 @@ package csvutil
 import (
 	"encoding"
 	"encoding/base64"
+	"math"
 	"reflect"
 	"strconv"
 )
@@ -47,7 +48,9 @@ func decodeFloat(t reflect.Type) decodeFunc {
 	bits := t.Bits()
 	return func(s string, v reflect.Value) error {
 		n, err := strconv.ParseFloat(s, bits)
-		if err != nil {
+		if err != nil && s == "" {
+			n = math.NaN()
+		} else if err != nil {
 			return &UnmarshalTypeError{Value: s, Type: t}
 		}
 		v.SetFloat(n)


### PR DESCRIPTION
A very common use case in parsing csv's is that the empty string for type float64 IEEE is parsed as NaN almost universally. This should cause many users of this lib to nan get an unexpected "cannot unmarshall..." error.