### PR TITLE
custom ignores - WIP

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -157,6 +157,10 @@ func decodeFn(typ reflect.Type) (decodeFunc, error) {
 			return decodeBytes, nil
 		}
 	}
+	//return nil, &UnsupportedTypeError{Type: typ}
+	return emptyFunc, &UnsupportedTypeError{Type: typ}
+}
 
-	return nil, &UnsupportedTypeError{Type: typ}
+func emptyFunc(s string, v reflect.Value) error {
+	return nil
 }

--- a/decoder.go
+++ b/decoder.go
@@ -224,7 +224,7 @@ func (d *Decoder) unmarshalStruct(record []string, v reflect.Value) error {
 			s = d.Map(s, d.header[f.columnIndex], zero)
 		}
 
-		if err := f.decodeFunc(s, fv); err != nil {
+		if err := f.decodeFunc(s, fv); err != nil && !f.tag.ignoreCustom {
 			return err
 		}
 	}
@@ -247,7 +247,7 @@ func (d *Decoder) fields(k typeKey) ([]decField, error) {
 		}
 
 		fn, err := decodeFn(f.typ)
-		if err != nil {
+		if err != nil && ! f.tag.ignoreCustom {
 			return nil, err
 		}
 

--- a/tag.go
+++ b/tag.go
@@ -6,10 +6,11 @@ import (
 )
 
 type tag struct {
-	name      string
-	empty     bool
-	omitEmpty bool
-	ignore    bool
+	name         string
+	empty        bool
+	omitEmpty    bool
+	ignore       bool
+	ignoreCustom bool
 }
 
 func parseTag(tagname string, field reflect.StructField) (t tag) {
@@ -23,6 +24,11 @@ func parseTag(tagname string, field reflect.StructField) (t tag) {
 	case "-":
 		t.ignore = true
 		return
+	case "!":
+		t.ignoreCustom = true
+		if len(tags) == 2 {
+			t.name = tags[1]
+		}
 	case "":
 		t.name = field.Name
 	default:


### PR DESCRIPTION
Hi Jacek, thank you for writing your library it's very useful.

I'm working on a feature, I'd be interested in your feedback (the PR isn't ready yet).

I'm trying to import into `sql.NullString` fields. But this type doesn't implement `encoding.TextUnmarshaller` (nor `csvutil.Unmarshaler`, obviously), so I can't import. I'm trying to design a way of allowing ad-hoc decoding, by doing reflection in a custom `dec.Map` (inspired by your example in `example_decoder_interface_test.go ExampleDecoder_interfaceValues()`).

My current idea is to add another `csvutil` tag - `!`, here's an example:

```
type ATable struct {
	Name        string          `db:"name" csv:"name"`
	LastMessage *sql.NullString `db:"last_message" csv:"!,last_message"`
}
```

What do you think, am I approaching this in the right way?

