### PR TITLE
feat: add FailSlow flag to Decoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jszwec/csvutil
 
-go 1.18
+go 1.21


### PR DESCRIPTION
### Description
Added a new flag call `FailSlow` to decoder

```go
// FailSlow, if true, allows the Decoder to continue decoding
// records even if errors are encountered. This provides a
// more lenient decoding approach, attempting to recover
// as much valid data as possible. If false, the Decoder
// stops on the first encountered error.
//
// Default: false
FailSlow bool
```

**Usage**
```go
dec, _ := csvutil.NewDecoder(csvReader)
dec.FailSlow = true
```



### Checklist
- [x] Code compiles without errors
- [x] Added new tests for the provided functionality
- [x] All tests are passing
- [ ] Updated the README and/or documentation, if necessary
