### PR TITLE
Escaping in headers

### DIFF
--- a/example_header_test.go
+++ b/example_header_test.go
@@ -10,9 +10,9 @@ import (
 func ExampleHeader() {
 	type User struct {
 		ID    int
-		Name  string
-		Age   int `csv:",omitempty"`
-		State int `csv:"-"`
+		Name  string `csv:"Last Name\\, First Name"`
+		Age   int    `csv:",omitempty"`
+		State int    `csv:"-"`
 		City  string
 		ZIP   string `csv:"zip_code"`
 	}
@@ -24,5 +24,5 @@ func ExampleHeader() {
 
 	fmt.Println(header)
 	// Output:
-	// [ID Name Age City zip_code]
+	// [ID Last Name, First Name Age City zip_code]
 }

--- a/tag.go
+++ b/tag.go
@@ -14,8 +14,22 @@ type tag struct {
 	inline    bool
 }
 
+// credit to Pascal de Kloe on stackexchange for this function
+// https://codereview.stackexchange.com/a/280193
+func splitEscapedString(s, separator, escapeString string) []string {
+	a := strings.Split(s, separator)
+
+	for i := len(a) - 2; i >= 0; i-- {
+		if strings.HasSuffix(a[i], escapeString) {
+			a[i] = a[i][:len(a[i])-len(escapeString)] + separator + a[i+1]
+			a = append(a[:i+1], a[i+2:]...)
+		}
+	}
+	return a
+}
+
 func parseTag(tagname string, field reflect.StructField) (t tag) {
-	tags := strings.Split(field.Tag.Get(tagname), ",")
+	tags := splitEscapedString(field.Tag.Get(tagname), ",", "\\")
 	if len(tags) == 1 && tags[0] == "" {
 		t.name = field.Name
 		t.empty = true


### PR DESCRIPTION
### Description
Csvutil can not currently read or write headers with commas in the name. This allows users to escape commas with `\\,` in the struct tags.

### Checklist
- [ ] Code compiles without errors
- [x] Added new tests for the provided functionality
- [x] All tests are passing
- [ ] Updated the README and/or documentation, if necessary

I do not know what code there is to compile within the module. I don't have experience writing documentation and didn't know where to put this functionality.