### PR TITLE
Do not embed reflect.Type to avoid supressing DCE

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -42,7 +42,7 @@ func (fs fields) Less(i, j int) bool {
 
 type typeKey struct {
 	tag string
-	reflect.Type
+	typ reflect.Type
 }
 
 type fieldMap map[string]fields
@@ -92,7 +92,7 @@ func buildFields(k typeKey) fields {
 		tag
 	}
 
-	q := fields{{typ: k.Type}}
+	q := fields{{typ: k.typ}}
 	visited := make(map[key]struct{})
 	fm := make(fieldMap)
 


### PR DESCRIPTION
It's [a known artifact of go's linker](https://go.googlesource.com/go/+/refs/tags/go1.23.2/src/cmd/link/internal/ld/deadcode.go#405) that referencing `Method` or `MethodByName` anywhere in the code suppresses dead-code elimination for public methods for the entire program. This includes embedding `reflect.Type`, since that references `Method` and `MethodByName`. By simply not embedding reflect.Type, we avoid that.